### PR TITLE
Fix the user-data passwd field

### DIFF
--- a/src/ccmodules/users.c
+++ b/src/ccmodules/users.c
@@ -67,7 +67,7 @@ static struct users_options_data users_options[] = {
 	{"groups",		users_add_groups,	        NULL    	},
 	{"lock-passwd",		NULL,				NULL		},
 	{"inactive",		NULL,				NULL		},
-	{"passwd",		users_add_option_format,	" -p %s "	},
+	{"passwd",		users_add_option_format,	" -p '%s' "	},
 	{"no-create-home",	users_add_option,		" -M , -m "	},
 	{"no-user-group",	users_add_option,		" -N , -U "	},
 	{"no-log-init",		users_add_option,		" -l ,"		},


### PR DESCRIPTION
The contents of the passwd field need to be quoted before being
passed to useradd.  Password hashes often contain $ symbols and
without the quotes these symbols are interpeted as shell variables.
The result being that the hash you specify in your yaml bears
little resemblance to the hash that ends up in /etc/shadow and
your user cannot log in.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>