### PR TITLE
Mask -Werror behind --enable-werror flag, disable it by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,11 +5,8 @@ ACLOCAL_AMFLAGS=-I m4
 AM_CPPFLAGS = -I $(top_srcdir)/src -I $(top_srcdir)/src/interpreters -I $(top_srcdir)/src/datasources
 AM_CFLAGS = -std=gnu99 -fstack-protector -Wall -pedantic \
 	-Wstrict-prototypes -Wundef -fno-common \
-	-Werror-implicit-function-declaration \
-	-Wformat -Wformat-security -Werror=format-security \
-	-Wconversion -Wunused-variable -Wunreachable-code \
-	-Wall -W -Werror
-
+	-Wformat -Wformat-security  -Wconversion -Wunused-variable
+	-Wunreachable-code -Wall -W
 
 EXTRA_DIST = \
 	LICENSE \
@@ -17,7 +14,8 @@ EXTRA_DIST = \
 	data/cloud-init.service.in
 
 DISTCHECK_CONFIGURE_FLAGS =  \
-	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir) --enable-debug
+	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir) --enable-debug \
+	--disable-werror
 
 dist_man_MANS = \
 	docs/cloud-init.1 \

--- a/autogen.sh
+++ b/autogen.sh
@@ -14,6 +14,6 @@ args="\
 
 if test -z "${NOCONFIGURE}"; then
   set -x
-  ./configure CFLAGS='-g -O0' $args "$@"
+  ./configure CFLAGS='-g -O0' $args "$@" --enable-werror
   make clean
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([clr-cloud-init],[17],[dev@clearlinux.org])
-AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([foreign -Wall -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_FILES([Makefile
 		tests/Makefile
@@ -36,6 +36,16 @@ AS_IF([test x"$disable_tests" = "xno"],
 	[AC_SUBST([BUILD_TESTS], [1])],
 	[AC_SUBST([BUILD_TESTS], [0])])
 AM_CONDITIONAL([BUILD_TESTS], [test x$disable_tests = x"no"])
+
+AC_ARG_ENABLE(werror, AS_HELP_STRING([--enable-werror], [enable -Werror and similar @<:@default=no@:>@]),
+        [], [enable_werror=yes])
+
+changequote(,)dnl
+if test x"$enable_werror" = x"yes"; then
+    CFLAGS="$CFLAGS -Werror -Werror-implicit-function-declaration -Werror=format-security"
+fi
+changequote([,])dnl
+
 
 # Checks for libraries.
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.24.1])


### PR DESCRIPTION
Ensures that `-Werror` is only used during development.