### PR TITLE
Update sudo documentation.

### DIFF
--- a/docs/cloud-config.5
+++ b/docs/cloud-config.5
@@ -245,7 +245,8 @@ no-log-init
 expiredate string    no           A date at which to expire the password
 ssh-authorized-keys
            string[]  no           Add SSH public keys to ssh configuration
-sudo       string[]  no           Add sudoers lines for this account
+sudo       string[]  no           Add sudoers lines for this account, the account
+                                  name is automatically prepended
 system     boolean   no           Make the account a system account
 .TE
 .RE


### PR DESCRIPTION
clr-cloud-init will now always insert a username as argument
1 on the sudoers file written out, so call that out in the
man page.