### PR TITLE
Allow package manager selection.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,26 @@ AC_ARG_WITH([datadir],[AC_HELP_STRING([--with-datadir=DIR],
 AC_SUBST([DATADIR], ["${datadir}"], [Default data directory])
 AC_DEFINE_UNQUOTED([DATADIR_PATH], ["$DATADIR"], [Default data directory])
 
+AC_ARG_WITH([packagemgr],[AS_HELP_STRING([--with-packagemgr=PKGMGR],[Default package manager (swupd|yum|dnf|apt)])], [packagemgr=${withval}],[packagemgr=swupd])
+AC_SUBST([PKGMGR], ["${packagemgr}"], [Default package manager])
+if test "x$PKGMGR" = "xswupd" ; then
+	AC_DEFINE([PACKAGE_MANAGER_SWUPD], [1], [Define if swupd package manager selected])
+else
+	if test "x$PKGMGR" = "xyum" ; then
+		AC_DEFINE([PACKAGE_MANAGER_YUM], [1], [Define if yum package manager selected])
+	else
+		if test "x$PKGMGR" = "xdnf" ; then
+			AC_DEFINE([PACKAGE_MANAGER_DNF], [1], [Define if dnf package manager selected])
+		else
+			if test "x$PKGMGR" = "xapt" ; then
+				AC_DEFINE([PACKAGE_MANAGER_APT], [1], [Define if apt package manager selected])
+			else
+				AC_MSG_ERROR([Please provide a valid package manager (swupd, yum, dnf, or apt).])
+			fi
+		fi
+	fi
+fi
+
 # Checks for library functions.
 
 AC_OUTPUT

--- a/src/ccmodules/package_upgrade.c
+++ b/src/ccmodules/package_upgrade.c
@@ -57,7 +57,15 @@ void package_upgrade_handler(GNode *node) {
 	}
 	if (do_upgrade) {
 		LOG(MOD "Performing system software update.\n");
+#if defined(PACKAGE_MANAGER_SWUPD)
 		exec_task("/usr/bin/swupd update");
+#elif defined(PACKAGE_MANAGER_YUM)
+		exec_task("/usr/bin/yum update");
+#elif defined(PACKAGE_MANAGER_DNF)
+		exec_task("/usr/bin/dnf update --refresh");
+#elif defined(PACKAGE_MANAGER_APT)
+		exec_task("/usr/bin/apt-get upgrade");
+#endif
 	} else {
 		LOG(MOD "Skipping system software update.\n");
 	}

--- a/src/ccmodules/packages.c
+++ b/src/ccmodules/packages.c
@@ -46,7 +46,16 @@
 
 static gboolean packages_item(GNode* node, __unused__ gpointer data) {
 	gchar command[COMMAND_SIZE];
-	g_snprintf(command, COMMAND_SIZE, "/usr/bin/swupd bundle-add %s",
+	g_snprintf(command, COMMAND_SIZE,
+#if defined(PACKAGE_MANAGER_SWUPD)
+		"/usr/bin/swupd bundle-add %s",
+#elif defined(PACKAGE_MANAGER_YUM)
+		"/usr/bin/yum install %s",
+#elif defined(PACKAGE_MANAGER_DNF)
+		"/usr/bin/dnf install %s",
+#elif defined(PACKAGE_MANAGER_APT)
+		"/usr/bin/apt-get install %s",
+#endif
 		(char*)node->data);
 	LOG(MOD "Installing %s..\n", (char*)node->data);
 	exec_task(command);


### PR DESCRIPTION
Supported package managers are: swupd (default), yum, dnf, apt.

If configure is passwd --with-packagemgr=<pkgmgr>, then the appropriate
calls to dnf/yum etc. are used instead of `swupd`. This affects the
`packge_upgrade' and `packages' directives, exclusively.

This is determined at compile time, without checking for dependencies
being actually present. This seems preferable than to try and determine
at runtime what support is present.