### PR TITLE
Small build fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,6 +59,9 @@ cloud_init_SOURCES = \
 	src/async_task.c \
 	src/async_task.h
 
+if ENABLE_WERROR
+AM_CFLAGS += -Werror
+endif
 if DEBUG
 AM_CFLAGS += -ggdb3 -O0
 cloud_init_SOURCES += src/debug.c

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([clr-cloud-init],[22],[dev@clearlinux.org])
-AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([foreign -Wall -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_FILES([Makefile
 		tests/Makefile
@@ -30,6 +30,11 @@ AS_IF([test "x$enable_debug" = "xyes"],
 	[AC_DEFINE([DEBUG], [1], [Debugging mode enabled])],
 	[AC_DEFINE([NDEBUG], [1], [Debugging and assertions disabled])])
 AM_CONDITIONAL([DEBUG], [test x$enable_debug = x"yes"])
+
+# Enable -Werror for harder flags.
+AC_ARG_ENABLE(werror, AS_HELP_STRING([--enable-werror], [enable Werror @<:@default=no@:>@]),
+	      [], [enable_werror=no])
+AM_CONDITIONAL([ENABLE_WERROR], [test x$enable_werror = x"yes"])
 
 AC_ARG_ENABLE(tests, AS_HELP_STRING([--disable-tests], [do not build unit tests @<:@default=no@:>@]),
 	      [], [disable_tests=no])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,17 +43,17 @@ libtest_la_CFLAGS = $(COMMON_CFLAGS)
 
 lib_test_SOURCES = lib_test.c
 lib_test_CFLAGS = $(COMMON_CFLAGS) $(AM_CFLAGS)
-lib_test_LDADD = $(COMMON_LDADD) libtest.la
+lib_test_LDADD = libtest.la $(COMMON_LDADD)
 TESTS += lib_test
 
 curl_test_SOURCES = curl_test.c
 curl_test_CFLAGS = $(COMMON_CFLAGS)
-curl_test_LDADD = $(COMMON_LDADD) libtest.la
+curl_test_LDADD = libtest.la $(COMMON_LDADD)
 TESTS += curl_test
 
 userdata_test_SOURCES = userdata_test.c
 userdata_test_CFLAGS = $(COMMON_CFLAGS)
-userdata_test_LDADD = $(COMMON_LDADD) libtest.la
+userdata_test_LDADD = libtest.la $(COMMON_LDADD)
 TESTS += userdata_test
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,7 +42,7 @@ endif
 libtest_la_CFLAGS = $(COMMON_CFLAGS)
 
 lib_test_SOURCES = lib_test.c
-lib_test_CFLAGS = $(COMMON_CFLAGS)
+lib_test_CFLAGS = $(COMMON_CFLAGS) $(AM_CFLAGS)
 lib_test_LDADD = $(COMMON_LDADD) libtest.la
 TESTS += lib_test
 


### PR DESCRIPTION
First fix adds a new `--enable-werror` option which can be used during development to ensure that everything is working ok, but not to force it upon builds of others.

The second fix allows building where `-Wl,--as-needed` is employed, whether in `$CFLAGS` or forcibly such as `LD_AS_NEEDED` binutils change.

Source: ikeydoherty/clr-boot-manager@b5c75779e7119effea7070337519593bf72ab51c

Was unsure if you'd want `--enable-werror` in autogen by default, so I've left it up to reviewer discretion.