### PR TITLE
fix wrong retcode check for write_lines function

### DIFF
--- a/src/ucd-data-fetch.c
+++ b/src/ucd-data-fetch.c
@@ -282,7 +282,7 @@ int main(int argc, char *argv[]) {
 		FAIL("write()");
 	}
 
-	if (!write_lines(out, f, cl)) {
+	if (write_lines(out, f, cl) != 0) {
 		close(out);
 		fclose(f);
 		unlink(outpath);
@@ -339,7 +339,7 @@ int main(int argc, char *argv[]) {
 		FAIL("parse_headers()");
 	}
 
-	if (!write_lines(out, f, cl)) {
+	if (write_lines(out, f, cl) != 0) {
 		close(out);
 		fclose(f);
 		unlink(outpath);


### PR DESCRIPTION
write_lines return 0 means succeed, thus !write_lines go into error
handling path, which is not expected.

Signed-off-by: jwang <jing.j.wang@intel.com>