### PR TITLE
Add support for uid on user objects

### DIFF
--- a/docs/cloud-config.5.md
+++ b/docs/cloud-config.5.md
@@ -185,6 +185,8 @@ ssh-authorized-keys|string[]|no  |Add SSH public keys to ssh configuration
 sudo      |string[] |no          |Add sudoers lines for this account, the account
           |         |            |name is automatically prepended
 system    |boolean  |no          |Make the account a system account
+uid       |string   |no          |User ID, when not given system will
+          |         |            |determine and use the next free one
 ```
 
 ### write_files

--- a/src/ccmodules/users.c
+++ b/src/ccmodules/users.c
@@ -74,6 +74,7 @@ static struct users_options_data users_options[] = {
 	{"ssh-authorized-keys", NULL,                       NULL        },
 	{"sudo",                NULL,                       NULL        },
 	{"system",              users_add_option_format,    " -r "      },
+	{"uid",                 users_add_option_format,    " -u '%s' " },
 	{NULL}
 };
 


### PR DESCRIPTION
This PR adds support for the uid property on user objects.

Solves a part of #27.

Setting gid is currently also not supported on cloud-init.